### PR TITLE
CCD-4329: Update CCD Data Migration Tool to prevent data corruption via concurrency

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -9,7 +9,7 @@ plugins {
   id 'com.github.kt3k.coveralls' version '2.8.2'
   id 'com.github.ben-manes.versions' version '0.42.0'
   id 'org.sonarqube' version '3.4.0.2513'
-  id 'uk.gov.hmcts.java' version '0.12.34'
+  id 'uk.gov.hmcts.java' version '0.12.41'
 }
 
 group = 'uk.gov.hmcts.reform'

--- a/charts/ccd-migration/Chart.yaml
+++ b/charts/ccd-migration/Chart.yaml
@@ -8,5 +8,5 @@ maintainers:
   - name: HMCTS ccd team
 dependencies:
   - name: job
-    version: ~0.7.5
+    version: ~0.7.10
     repository: 'https://hmctspublic.azurecr.io/helm/v1/repo/'

--- a/src/main/java/uk/gov/hmcts/reform/migration/CaseMigrationProcessor.java
+++ b/src/main/java/uk/gov/hmcts/reform/migration/CaseMigrationProcessor.java
@@ -108,7 +108,8 @@ public class CaseMigrationProcessor {
                     EVENT_SUMMARY,
                     EVENT_DESCRIPTION,
                     caseType,
-                    caseDetails
+                    caseDetails.getId(),
+                    caseDetails.getJurisdiction()
                 );
                 log.info("Case {} successfully updated", id);
                 migratedCases.add(id);

--- a/src/main/java/uk/gov/hmcts/reform/migration/ccd/CoreCaseDataService.java
+++ b/src/main/java/uk/gov/hmcts/reform/migration/ccd/CoreCaseDataService.java
@@ -11,6 +11,9 @@ import uk.gov.hmcts.reform.ccd.client.model.StartEventResponse;
 import uk.gov.hmcts.reform.idam.client.IdamClient;
 import uk.gov.hmcts.reform.idam.client.models.UserDetails;
 import uk.gov.hmcts.reform.migration.auth.AuthUtil;
+import uk.gov.hmcts.reform.migration.service.DataMigrationService;
+
+import java.util.Map;
 
 @Service
 public class CoreCaseDataService {
@@ -21,6 +24,8 @@ public class CoreCaseDataService {
     private AuthTokenGenerator authTokenGenerator;
     @Autowired
     private CoreCaseDataApi coreCaseDataApi;
+    @Autowired
+    private DataMigrationService<Map<String, Object>> dataMigrationService;
 
     public CaseDetails update(String authorisation, String eventId,
                               String eventSummary,
@@ -49,7 +54,7 @@ public class CoreCaseDataService {
                     .summary(eventSummary)
                     .description(eventDescription)
                     .build()
-            ).data(updatedCaseDetails.getData())
+            ).data(dataMigrationService.migrate(updatedCaseDetails.getData()))
             .build();
 
         return coreCaseDataApi.submitEventForCaseWorker(

--- a/src/main/java/uk/gov/hmcts/reform/migration/ccd/CoreCaseDataService.java
+++ b/src/main/java/uk/gov/hmcts/reform/migration/ccd/CoreCaseDataService.java
@@ -63,7 +63,7 @@ public class CoreCaseDataService {
             userDetails.getId(),
             updatedCaseDetails.getJurisdiction(),
             caseType,
-            String.valueOf(caseId),
+            String.valueOf(updatedCaseDetails.getId()),
             true,
             caseDataContent);
     }

--- a/src/main/java/uk/gov/hmcts/reform/migration/ccd/CoreCaseDataService.java
+++ b/src/main/java/uk/gov/hmcts/reform/migration/ccd/CoreCaseDataService.java
@@ -31,17 +31,17 @@ public class CoreCaseDataService {
                               String eventSummary,
                               String eventDescription,
                               String caseType,
-                              CaseDetails caseDetails) {
-        String caseId = String.valueOf(caseDetails.getId());
+                              Long caseId,
+                              String jurisdiction) {
         UserDetails userDetails = idamClient.getUserDetails(AuthUtil.getBearerToken(authorisation));
 
         StartEventResponse startEventResponse = coreCaseDataApi.startEventForCaseWorker(
             AuthUtil.getBearerToken(authorisation),
             authTokenGenerator.generate(),
             userDetails.getId(),
-            caseDetails.getJurisdiction(),
+            jurisdiction,
             caseType,
-            caseId,
+            String.valueOf(caseId),
             eventId);
 
         CaseDetails updatedCaseDetails = startEventResponse.getCaseDetails();
@@ -63,7 +63,7 @@ public class CoreCaseDataService {
             userDetails.getId(),
             updatedCaseDetails.getJurisdiction(),
             caseType,
-            caseId,
+            String.valueOf(caseId),
             true,
             caseDataContent);
     }

--- a/src/main/java/uk/gov/hmcts/reform/migration/ccd/CoreCaseDataService.java
+++ b/src/main/java/uk/gov/hmcts/reform/migration/ccd/CoreCaseDataService.java
@@ -39,6 +39,8 @@ public class CoreCaseDataService {
             caseId,
             eventId);
 
+        CaseDetails updatedCaseDetails = startEventResponse.getCaseDetails();
+
         CaseDataContent caseDataContent = CaseDataContent.builder()
             .eventToken(startEventResponse.getToken())
             .event(
@@ -47,14 +49,14 @@ public class CoreCaseDataService {
                     .summary(eventSummary)
                     .description(eventDescription)
                     .build()
-            ).data(caseDetails.getData())
+            ).data(updatedCaseDetails.getData())
             .build();
 
         return coreCaseDataApi.submitEventForCaseWorker(
             AuthUtil.getBearerToken(authorisation),
             authTokenGenerator.generate(),
             userDetails.getId(),
-            caseDetails.getJurisdiction(),
+            updatedCaseDetails.getJurisdiction(),
             caseType,
             caseId,
             true,

--- a/src/test/java/uk/gov/hmcts/reform/migration/CaseMigrationProcessorTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/migration/CaseMigrationProcessorTest.java
@@ -66,7 +66,7 @@ public class CaseMigrationProcessorTest {
         List<CaseDetails> listOfCaseDetails = elasticSearchRepository.findCaseByCaseType(USER_TOKEN, CASE_TYPE);
         assertNotNull(listOfCaseDetails);
         when(coreCaseDataService.update(USER_TOKEN, EVENT_ID, EVENT_SUMMARY,
-                                        EVENT_DESCRIPTION, CASE_TYPE, details))
+                                        EVENT_DESCRIPTION, CASE_TYPE, details.getId(), details.getJurisdiction()))
             .thenReturn(details);
         caseMigrationProcessor.migrateCases(CASE_TYPE);
         verify(coreCaseDataService, times(1))
@@ -75,7 +75,8 @@ public class CaseMigrationProcessorTest {
                     EVENT_SUMMARY,
                     EVENT_DESCRIPTION,
                     CASE_TYPE,
-                    details);
+                    details.getId(),
+                    details.getJurisdiction());
     }
 
     @Test
@@ -92,7 +93,7 @@ public class CaseMigrationProcessorTest {
         List<CaseDetails> listOfCaseDetails = elasticSearchRepository.findCaseByCaseType(USER_TOKEN, CASE_TYPE);
         assertNotNull(listOfCaseDetails);
         when(coreCaseDataService.update(USER_TOKEN, EVENT_ID, EVENT_SUMMARY,
-                                        EVENT_DESCRIPTION, CASE_TYPE, details))
+                                        EVENT_DESCRIPTION, CASE_TYPE, details.getId(), details.getJurisdiction()))
             .thenReturn(details);
         caseMigrationProcessor.migrateCases(CASE_TYPE);
         verify(coreCaseDataService, times(1))
@@ -101,7 +102,8 @@ public class CaseMigrationProcessorTest {
                     EVENT_SUMMARY,
                     EVENT_DESCRIPTION,
                     CASE_TYPE,
-                    details);
+                    details.getId(),
+                    details.getJurisdiction());
     }
 
     @Test

--- a/src/test/java/uk/gov/hmcts/reform/migration/ccd/CoreCaseDataServiceTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/migration/ccd/CoreCaseDataServiceTest.java
@@ -69,7 +69,8 @@ public class CoreCaseDataServiceTest {
         setupMocks(userDetails, caseDetails3.getData());
 
         //when
-        CaseDetails update = underTest.update(AUTH_TOKEN, EVENT_ID, EVENT_SUMMARY, EVENT_DESC, CASE_TYPE, caseDetails3);
+        CaseDetails update = underTest.update(AUTH_TOKEN, EVENT_ID, EVENT_SUMMARY, EVENT_DESC, CASE_TYPE,
+                                              caseDetails3.getId(), caseDetails3.getJurisdiction());
         //then
         assertThat(update.getId(), is(Long.parseLong(CASE_ID)));
         assertThat(update.getData().get("solicitorEmail"), is("Padmaja.Ramisetti@hmcts.net"));

--- a/src/test/java/uk/gov/hmcts/reform/migration/ccd/CoreCaseDataServiceTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/migration/ccd/CoreCaseDataServiceTest.java
@@ -95,9 +95,15 @@ public class CoreCaseDataServiceTest {
 
         when(authTokenGenerator.generate()).thenReturn(AUTH_TOKEN);
 
+        CaseDetails caseDetails = CaseDetails.builder()
+            .id(123456789L)
+            .data(data)
+            .build();
+
         StartEventResponse startEventResponse = StartEventResponse.builder()
             .eventId(EVENT_ID)
             .token(EVENT_TOKEN)
+            .caseDetails(caseDetails)
             .build();
 
         when(coreCaseDataApi.startEventForCaseWorker(AUTH_TOKEN, AUTH_TOKEN, "30",
@@ -116,10 +122,6 @@ public class CoreCaseDataServiceTest {
             .ignoreWarning(false)
             .build();
 
-        CaseDetails caseDetails = CaseDetails.builder()
-            .id(123456789L)
-            .data(data)
-            .build();
         when(coreCaseDataApi.submitEventForCaseWorker(AUTH_TOKEN, AUTH_TOKEN, USER_ID, null,
                                                       CASE_TYPE, CASE_ID, true, caseDataContent
         )).thenReturn(caseDetails);

--- a/src/test/java/uk/gov/hmcts/reform/migration/ccd/CoreCaseDataServiceTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/migration/ccd/CoreCaseDataServiceTest.java
@@ -14,6 +14,7 @@ import uk.gov.hmcts.reform.ccd.client.model.Event;
 import uk.gov.hmcts.reform.ccd.client.model.StartEventResponse;
 import uk.gov.hmcts.reform.idam.client.IdamClient;
 import uk.gov.hmcts.reform.idam.client.models.UserDetails;
+import uk.gov.hmcts.reform.migration.service.DataMigrationService;
 
 import java.util.LinkedHashMap;
 import java.util.Map;
@@ -45,6 +46,9 @@ public class CoreCaseDataServiceTest {
 
     @Mock
     private AuthTokenGenerator authTokenGenerator;
+
+    @Mock
+    private DataMigrationService<Map<String, Object>> dataMigrationService;
 
 
     @Before
@@ -105,6 +109,9 @@ public class CoreCaseDataServiceTest {
             .token(EVENT_TOKEN)
             .caseDetails(caseDetails)
             .build();
+
+        when(dataMigrationService.migrate(data))
+            .thenReturn(data);
 
         when(coreCaseDataApi.startEventForCaseWorker(AUTH_TOKEN, AUTH_TOKEN, "30",
                                                      null, CASE_TYPE, CASE_ID, EVENT_ID


### PR DESCRIPTION
### JIRA link ###
https://tools.hmcts.net/jira/browse/CCD-4329

### Change description ###
Update CCD Data Migration Tool to use CCD case data from Start Event instead of case data which is being passed as this can be outdated.  Case data from Start Event API will have all the latest case data and by doing this we will be avoiding any loss of data.

**Does this PR introduce a breaking change?**
```
[ ] Yes
[x] No
```