### PR TITLE
CCD-4398 Upgrade dependencies to resolve CVE-2023-24998

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -216,6 +216,7 @@ dependencies {
 
   testImplementation 'com.github.hmcts:fortify-client:1.2.2:all'
 
+  implementation group: 'commons-fileupload', name: 'commons-fileupload', version: '1.5'
   implementation group: 'commons-io', name: 'commons-io', version: '2.8.0'
   implementation group: 'org.springframework.security', name: 'spring-security-oauth2-resource-server', version: springSecurity
   implementation group: 'org.springframework.security', name: 'spring-security-oauth2-client', version: springSecurity

--- a/charts/ccd-migration/Chart.yaml
+++ b/charts/ccd-migration/Chart.yaml
@@ -3,10 +3,10 @@ appVersion: "1.0"
 description: A Helm chart for ccd-migration App
 name: ccd-migration
 home: https://github.com/hmcts/ccd-case-migration-starter
-version: 0.0.3
+version: 0.0.4
 maintainers:
   - name: HMCTS ccd team
 dependencies:
   - name: job
-    version: ~0.7.10
+    version: ~0.7.11
     repository: 'https://hmctspublic.azurecr.io/helm/v1/repo/'

--- a/config/owasp/suppressions.xml
+++ b/config/owasp/suppressions.xml
@@ -9,8 +9,10 @@
   <suppress>
     <notes>Temporary Suppression
         CVE-2022-45688 refer https://tools.hmcts.net/jira/browse/CCD-4373
+        CVE-2022-1471 refer https://tools.hmcts.net/jira/browse/CCD-4454
     </notes>
     <cve>CVE-2022-45688</cve>
+    <cve>CVE-2022-1471</cve>
   </suppress>
   <!--End of temporary suppression section -->
 

--- a/config/owasp/suppressions.xml
+++ b/config/owasp/suppressions.xml
@@ -10,7 +10,6 @@
     <notes>Temporary Suppression</notes>
     <cve>CVE-2022-31690</cve>
     <cve>CVE-2022-31692</cve>
-    <cve>CVE-2023-24998</cve>
     <cve>CVE-2022-45688</cve>
   </suppress>
   <!--End of temporary suppression section -->


### PR DESCRIPTION
### JIRA link (if applicable) ###
https://tools.hmcts.net/jira/browse/CCD-4398


### Change description ###
Upgrade tomcat and commons-fileupload  to resolve CVE-2023-24998

**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[ x] No
```
