### PR TITLE
Replace JitPack with Azure DevOps Artifacts

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -158,7 +158,10 @@ dependencyCheck {
 repositories {
   mavenLocal()
   mavenCentral()
-  maven { url = 'https://jitpack.io' }
+  maven { 
+    name = "AzureArtifacts"
+    url = uri("https://pkgs.dev.azure.com/hmcts/Artifacts/_packaging/hmcts-lib/maven/v1")
+  }
 }
 
 ext {
@@ -217,7 +220,7 @@ dependencies {
   implementation group: 'com.github.hmcts.java-logging', name: 'logging', version: '6.1.6'
 
   testImplementation libraries.junit5
-  testImplementation group: 'com.github.hmcts', name: 'fortify-client', version: '1.4.6', classifier: 'all'
+  testImplementation group: 'com.github.hmcts', name: 'fortify-client', version: '1.4.9', classifier: 'all'
   testImplementation group: 'io.rest-assured', name: 'rest-assured', version: '5.5.0'
   testImplementation group: 'org.springframework.boot', name: 'spring-boot-starter-test'
   testImplementation group: 'org.springframework.cloud', name: 'spring-cloud-starter-contract-stub-runner', version: '4.1.4'


### PR DESCRIPTION
### JIRA link (if applicable) ###

https://tools.hmcts.net/jira/browse/CME-558

### Change description ###

Replace JitPack with Azure DevOps Artifacts and upgraded Fortify client version

**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[X] No
```
